### PR TITLE
Release 2026.04.09.003

### DIFF
--- a/dist/wme-switch-uturns.user.js
+++ b/dist/wme-switch-uturns.user.js
@@ -2,7 +2,7 @@
 // @name         WME Switch Uturns
 // @name:uk      WME 🇺🇦 Switch Uturns
 // @name:ru      WME 🇺🇦 Switch Uturns
-// @version      2026.04.09.002
+// @version      2026.04.09.003
 // @description  Switches U-turns for a selected node or segment.
 // @description:uk Перемикач розворотів для обраної точки або сегменту.
 // @description:ru Переключатель разворотов для выбранной точки или сегмента.
@@ -86,7 +86,7 @@
     class UTurns extends WMEBase {
         constructor(name, settings = null) {
             super(name, settings);
-            this.layerEnabled = false;
+            this.layerEnabled = this.settings.get('layer');
             this.initTab();
             this.initLayer();
             this.initShortcuts();
@@ -112,14 +112,18 @@
                 styleContext: LAYER_STYLE.styleContext,
                 zIndex: 500,
             });
-            this.wmeSDK.Map.setLayerVisibility({ layerName: LAYER_NAME, visibility: false });
+            this.wmeSDK.Map.setLayerVisibility({ layerName: LAYER_NAME, visibility: this.layerEnabled });
             this.wmeSDK.LayerSwitcher.addLayerCheckbox({ name: LAYER_NAME });
-            this.wmeSDK.LayerSwitcher.setLayerCheckboxChecked({ name: LAYER_NAME, isChecked: false });
+            this.wmeSDK.LayerSwitcher.setLayerCheckboxChecked({ name: LAYER_NAME, isChecked: this.layerEnabled });
+            if (this.layerEnabled) {
+                this.highlightDisallowed();
+            }
             this.wmeSDK.Events.on({
                 eventName: 'wme-layer-checkbox-toggled',
                 eventHandler: (e) => {
                     if (e.name === LAYER_NAME) {
                         this.layerEnabled = e.checked;
+                        this.settings.set('layer', e.checked);
                         this.wmeSDK.Map.setLayerVisibility({ layerName: LAYER_NAME, visibility: e.checked });
                         if (e.checked) {
                             this.highlightDisallowed();
@@ -320,10 +324,13 @@
 
     var css_248z = "p.switch-u-turns-counter {\n  margin-top: 15px;\n  padding-left: 15px;\n}\np.switch-u-turns-info {\n  border-top: 1px solid #ccc;\n  color: #777;\n  font-size: x-small;\n  margin-top: 15px;\n  padding-top: 10px;\n  text-align: center;\n}\n\n#switch-u-turns {\n  padding: 16px;\n}\n\n#sidebar p.switch-u-turns-blue {\n  background-color: #0057B8;\n  color: white;\n  height: 32px;\n  text-align: center;\n  line-height: 32px;\n  font-size: 24px;\n  margin: 0;\n}\n\n#sidebar p.switch-u-turns-yellow {\n  background-color: #FFDD00;\n  color: black;\n  height: 32px;\n  text-align: center;\n  line-height: 32px;\n  font-size: 24px;\n  margin: 0;\n}\n";
 
+    const SETTINGS = {
+        layer: false,
+    };
     $(document).on('bootstrap.wme', () => {
         WMEUI.addTranslation(NAME, TRANSLATION);
         WMEUI.addStyle(css_248z);
-        new UTurns(NAME);
+        new UTurns(NAME, SETTINGS);
     });
 
 })();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wme-switch-uturns",
-  "version": "2026.04.09.002",
+  "version": "2026.04.09.003",
   "scripts": {
     "build": "rollup -c",
     "watch": "rollup -c -w"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,13 @@ import { TRANSLATION } from './translations'
 import { UTurns } from './uturns'
 import css from './style.css'
 
+const SETTINGS = {
+  layer: false,
+}
+
 $(document).on('bootstrap.wme', () => {
   WMEUI.addTranslation(NAME, TRANSLATION)
   WMEUI.addStyle(css)
 
-  new UTurns(NAME)
+  new UTurns(NAME, SETTINGS)
 })

--- a/src/uturns.ts
+++ b/src/uturns.ts
@@ -35,7 +35,7 @@ export class UTurns extends WMEBase {
   constructor (name: string, settings: any = null) {
     super(name, settings)
 
-    this.layerEnabled = false
+    this.layerEnabled = this.settings.get('layer')
 
     this.initTab()
     this.initLayer()
@@ -77,16 +77,21 @@ export class UTurns extends WMEBase {
       styleContext: LAYER_STYLE.styleContext,
       zIndex: 500,
     })
-    this.wmeSDK.Map.setLayerVisibility({ layerName: LAYER_NAME, visibility: false })
+    this.wmeSDK.Map.setLayerVisibility({ layerName: LAYER_NAME, visibility: this.layerEnabled })
 
     this.wmeSDK.LayerSwitcher.addLayerCheckbox({ name: LAYER_NAME })
-    this.wmeSDK.LayerSwitcher.setLayerCheckboxChecked({ name: LAYER_NAME, isChecked: false })
+    this.wmeSDK.LayerSwitcher.setLayerCheckboxChecked({ name: LAYER_NAME, isChecked: this.layerEnabled })
+
+    if (this.layerEnabled) {
+      this.highlightDisallowed()
+    }
 
     this.wmeSDK.Events.on({
       eventName: 'wme-layer-checkbox-toggled',
       eventHandler: (e: any) => {
         if (e.name === LAYER_NAME) {
           this.layerEnabled = e.checked
+          this.settings.set('layer', e.checked)
           this.wmeSDK.Map.setLayerVisibility({ layerName: LAYER_NAME, visibility: e.checked })
           if (e.checked) {
             this.highlightDisallowed()


### PR DESCRIPTION
## Summary

- Persist layer enabled/disabled state to localStorage via Settings
- Restore layer visibility and checkbox on page reload
- Auto-highlight disallowed U-turn nodes if layer was previously enabled

## Test plan

- [ ] Enable the "Disallowed U-Turns" layer in the Layers panel
- [ ] Reload the page — verify the layer is still enabled and dots are visible
- [ ] Disable the layer, reload — verify it stays disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)